### PR TITLE
Minor fixes in RbShift

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Layout/ExtraSpacing:
   AllowForAlignment: true
   ForceEqualSignAlignment: true
 
+Layout/SpaceAroundOperators:
+  AllowForAlignment: true
+
 Style/HashSyntax:
   Enabled: false
 
@@ -16,12 +19,15 @@ Style/GuardClause:
 Style/WordArray:
   EnforcedStyle: brackets
 
-Style/SpaceAroundOperators:
-  AllowForAlignment: true
-
 Metrics/LineLength:
   Enabled: true
   Max: 100
+
+Metrics/ClassLength:
+  Max: 150
+
+Metrics/ModuleLength:
+  Max: 150
 
 Metrics/BlockLength:
   Enabled: false


### PR DESCRIPTION
* Fix loop to wait for project deletion
* Fix token usage when its obtained from username/password
* Modify execute method to use open3, to distinct stdout and stderr
* Set rubocop class length limit to be same as in 3scale-amp-tests
* Move rubocop 'SpaceAroundOperator' to correct namespace

Signed-off-by: Miroslav Jaros <mirek@mijaros.cz>