### PR TITLE
 Delete by label fix - namespace has not been added to the oc delete all

### DIFF
--- a/lib/rb_shift/project.rb
+++ b/lib/rb_shift/project.rb
@@ -106,7 +106,7 @@ module RbShift
     # @param [String] label_value value of label in selector
     def delete_by_label(label_name, label_value)
       log.info "Deleting all resources with #{label_name} label set to #{label_value}"
-      @client.execute 'delete all', selector: "#{label_name}=#{label_value}"
+      execute 'delete all', selector: "#{label_name}=#{label_value}"
       invalidate
     end
 


### PR DESCRIPTION
`delete_by` was calling `@client.execute` instead of `execute`.
That was the reason why the Gateways had not been undeployed after the test run.

