### PR TITLE
Do not crash on missing/invalid env variable

### DIFF
--- a/lib/rb_shift/deployment_config.rb
+++ b/lib/rb_shift/deployment_config.rb
@@ -138,6 +138,7 @@ module RbShift
     # @param [Hash] obj valueFrom reference
     # @return [String] resolved value from the ConfigMap or a Secret
     def resolve_value(obj)
+      return unless obj
       project = @parent
       kind = case
              when (ref = obj[:configMapKeyRef]) then ConfigMap

--- a/lib/rb_shift/deployment_config.rb
+++ b/lib/rb_shift/deployment_config.rb
@@ -80,7 +80,7 @@ module RbShift
     def env_variables(container_name = nil)
       unless @_env
         cont       = container(container_name)
-        @_env      = cont[:env].each_with_object({}) do |var, env|
+        @_env      = Array(cont[:env]).each_with_object({}) do |var, env|
           env[var[:name]] = var.fetch(:value) { resolve_value(var[:valueFrom]) }
         end
       end


### PR DESCRIPTION
`resolve_value` could fail when passed `nil`.

This PR also shows why it is not great to rebase someone else commits on merge. 
I'd have to rebase my branch instead of just opening a PR from from the same commits as before.
My commits are the same commits, signed by me and have the same SHA as in https://github.com/jcechace/RbShift/pull/46