### PR TITLE
Add support for BuildConfig and Build objects

### DIFF
--- a/lib/rb_shift/build.rb
+++ b/lib/rb_shift/build.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'openshift_kind'
+
+module RbShift
+  # Representation of OpenShift build
+  class Build < OpenshiftKind
+    def phase
+      obj[:status][:phase]
+    end
+
+    def running?
+      reload
+      phase == 'Running' || phase == 'Pending'
+    end
+
+    def completed?
+      reload
+      phase == 'Completed'
+    end
+  end
+end

--- a/lib/rb_shift/build_config.rb
+++ b/lib/rb_shift/build_config.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'openshift_kind'
+require_relative 'build'
+
+module RbShift
+  # Representation of OpenShift build config
+  class BuildConfig < OpenshiftKind
+    def builds(update = false)
+      bc_label = 'openshift.io/build-config.name'.to_sym
+      if update || @_builds.nil?
+        items = @parent.client
+                  .get('builds', namespace: @parent.name)
+                  .select { |item| item[:metadata][:annotations][bc_label] == name }
+
+        @_builds = items.each_with_object({}) do |item, hash|
+          resource            = Build.new(self, item)
+          hash[resource.name] = resource
+        end
+      end
+      @_builds
+    end
+
+    def running?(reload = false)
+      builds(true) if reload
+      !builds.values.select(&:running?).empty?
+    end
+
+    def wait_for_build(timeout: 60, polling: 5)
+      Timeout.timeout(timeout) do
+        log.info "Waiting for builds of #{name} to be finished for #{timeout} seconds..."
+        loop do
+          log.debug "--> Checking builds after #{polling} seconds..."
+          sleep polling
+          break unless running?(true)
+        end
+      end
+      log.info 'Build finished'
+    end
+
+    def start_build(block: false, timeout: 60, polling: 5, **opts)
+      log.info "Starting build from BuildConfig #{name} with options #{opts}"
+      @parent.execute('start-build ', name, **opts)
+      sleep polling * 2
+      builds(true)
+      wait_for_build(timeout: timeout, polling: polling) if block
+    end
+  end
+end

--- a/lib/rb_shift/client.rb
+++ b/lib/rb_shift/client.rb
@@ -105,12 +105,17 @@ module RbShift
       log.debug("[EXEC] Executing command #{command} with opts: #{opts}")
       oc_cmd = oc_command(command, *args, **opts)
       stdout, stderr, stat = Open3.capture3(oc_cmd)
-      unless stderr.empty? && stat.success?
+      unless stat.success?
         log.error oc_command(command, *args, exclude_token: true, **opts)
         log.error "Command failed with status #{stat.exitstatus} -->"
         log.debug "Standard Output: #{stdout}"
         log.error "Error Output: #{stderr}"
         raise InvalidCommandError, "ERROR: #{stdout} #{stderr}"
+      end
+      unless stderr.empty?
+        log.warn "Command succeeded with status #{stat.exitstatus}, but stderr is not empty -->"
+        log.debug "Standard Output: #{stdout}"
+        log.warn "Error Output: #{stderr}"
       end
     end
 
@@ -137,7 +142,7 @@ module RbShift
     # rubocop:disable  Metrics/LineLength
     def oc_command(command, *args, exclude_token: false, **opts)
       token = exclude_token ? '***' : @token
-      "oc --server=\"#{@url}\" --token=\"#{token}\" #{command} #{unfold_opts opts} #{unfold_args args}"
+      "oc --server=\"#{@url}\" --token=\"#{token}\" #{command} #{unfold_args args} #{unfold_opts opts}"
     end
     # rubocop:enable  Metrics/LineLength
 

--- a/lib/rb_shift/openshift_kind.rb
+++ b/lib/rb_shift/openshift_kind.rb
@@ -38,7 +38,7 @@ module RbShift
       invalidate unless self_only
     end
 
-    def update(patch = nil)
+    def update(patch = nil, type = 'strategic')
       if patch
         @parent.invalidate
       else
@@ -46,11 +46,11 @@ module RbShift
       end
 
       log.info "Updating #{self.class.class_name} #{name}"
-      execute "patch #{self.class.class_name} #{name} -p #{patch.shellescape}"
+      execute "patch #{self.class.class_name} #{name} -p #{patch.shellescape}", :type => type
     end
 
-    def execute(command, **opts)
-      parent.execute(command, **opts) if parent.respond_to? :execute
+    def execute(command, *args, **opts)
+      parent.execute(command, *args, **opts) if parent.respond_to? :execute
     end
 
     def delete

--- a/lib/rb_shift/project.rb
+++ b/lib/rb_shift/project.rb
@@ -7,6 +7,7 @@ require_relative 'pod'
 require_relative 'secret'
 require_relative 'service'
 require_relative 'template'
+require_relative 'build_config'
 require_relative 'role_binding'
 
 module RbShift
@@ -51,6 +52,11 @@ module RbShift
     def role_bindings(update = false)
       @_role_bindings = init_objects(RoleBinding) if update || @_role_bindings.nil?
       @_role_bindings
+    end
+
+    def build_configs(update = false)
+      @_build_configs = init_objects(BuildConfig) if update || @_build_configs.nil?
+      @_build_configs
     end
 
     def routes(update = false)


### PR DESCRIPTION
- Added `Build` and `BuildConfig` classes for their respective objects.
- Changed handling of not empty stderr in `oc_command`.
  * Now it will not fail if return code is successful but stderr is not empty, it will instead just throw a warning.
  * Reasoning: Starting build from a local directory will write upload progress to stderr but will still succeed.
- Added option to pass `*args` to `execute` method of `OpenshiftKind`.
  * Reasoning: `start-build` command needs the name of the build.
- Switched order of `*args` and `**opts` when executing a command.
  * Reasoning: `start-build` needs name of the build as a first argument.
- Added option to pass type to `update` of `OpenshiftKind`.
  * Reasoning: Executing command like this one:
    * ` oc patch dc/system-app -p '[{"op": "add", "path": "/spec/strategy/rollingParams/pre/execNewPod/env/-", "value": {"name": "ORACLE_SYSTEM_PASSWORD", "value": "<<<<SYSTEM_PASSWORD>>>>"}}]' --type=json`